### PR TITLE
Single default export with frag and vert as properties of the exported object

### DIFF
--- a/example/pages/distortion-material.tsx
+++ b/example/pages/distortion-material.tsx
@@ -5,10 +5,10 @@ import { Sphere } from '@react-three/drei'
 import { useTweaks } from 'use-tweaks'
 import * as THREE from 'three'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
-
 import distortion from '../simplex3d'
-import { ComponentMaterial, vert } from '../../src/index'
 import hdr from '../studio_small_04_1k.hdr'
+
+import M from '../../src/index'
 
 function Env() {
   const { gl, scene } = useThree()
@@ -49,7 +49,7 @@ function Scene() {
 
   return (
     <Sphere args={[RADIUS, 512, 512]}>
-      <ComponentMaterial
+      <M
         ref={material}
         clearcoat={clearcoat}
         metalness={metalness}
@@ -61,7 +61,7 @@ function Scene() {
           radiusVariationAmplitude: { value: radiusVariationAmplitude, type: 'float' },
           radiusNoiseFrequency: { value: radiusNoiseFrequency, type: 'float' },
         }}>
-        <vert.head>{/*glsl*/ `
+        <M.vert.head>{/*glsl*/ `
           ${distortion}
           
           float fsnoise(float val1, float val2, float val3){
@@ -91,15 +91,15 @@ function Scene() {
             vec3 distorted2 = distortFunct(nearby2, 1.0);
             return normalize(cross(distorted1 - distortedPosition, distorted2 - distortedPosition));
           }
-        `}</vert.head>
-        <vert.body>{/*glsl*/ `
+        `}</M.vert.head>
+        <M.vert.body>{/*glsl*/ `
           float updateTime = time / 10.0;
           transformed = distortFunct(transformed, 1.0);
           vec3 distortedNormal = distortNormal(position, transformed, normal);
           vNormal = normal + distortedNormal;
           gl_Position = projectionMatrix * modelViewMatrix * vec4(transformed,1.);
-        `}</vert.body>
-      </ComponentMaterial>
+        `}</M.vert.body>
+      </M>
     </Sphere>
   )
 }

--- a/example/pages/main.tsx
+++ b/example/pages/main.tsx
@@ -5,9 +5,9 @@ import { Sphere } from '@react-three/drei'
 import { useTweaks } from 'use-tweaks'
 import * as THREE from 'three'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
-
-import { common, ComponentMaterial, frag } from '../../src/index'
 import hdr from '../studio_small_04_1k.hdr'
+
+import M from '../../src/index'
 
 function Env() {
   const { gl, scene } = useThree()
@@ -43,7 +43,7 @@ function Scene() {
 
   return (
     <Sphere args={[4, 512, 512]}>
-      <ComponentMaterial
+      <M
         ref={material}
         metalness={metalness}
         roughness={roughness}
@@ -51,16 +51,16 @@ function Scene() {
         uniforms={{
           time: { value: 0, type: 'float' },
         }}>
-        <frag.head>{/*glsl*/ `
+        <M.frag.head>{/*glsl*/ `
           float quadraticInOut(float t) {
             float p = 2.0 * t * t;
             return t < 0.5 ? p : -p + (4.0 * t) - 1.0;
           }
-        `}</frag.head>
-        <frag.body>{/*glsl*/ `
+        `}</M.frag.head>
+        <M.frag.body>{/*glsl*/ `
           gl_FragColor = vec4(gl_FragColor.rgb, quadraticInOut((sin(time)+1.0)/2.0));  
-        `}</frag.body>
-      </ComponentMaterial>
+        `}</M.frag.body>
+      </M>
     </Sphere>
   )
 }

--- a/example/pages/main.tsx
+++ b/example/pages/main.tsx
@@ -7,7 +7,7 @@ import * as THREE from 'three'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 import hdr from '../studio_small_04_1k.hdr'
 
-import M from '../../src/index'
+import {M} from '../../src/index'
 
 function Env() {
   const { gl, scene } = useThree()

--- a/example/pages/voronoi.tsx
+++ b/example/pages/voronoi.tsx
@@ -1,12 +1,12 @@
 import 'react-app-polyfill/ie11'
 import React, { Suspense, useEffect, useRef } from 'react'
 import { Canvas, useFrame, useLoader, useThree } from 'react-three-fiber'
-import { OrbitControls, Sphere } from '@react-three/drei'
+import { Sphere } from '@react-three/drei'
 import { useTweaks } from 'use-tweaks'
 import * as THREE from 'three'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 
-import { ComponentMaterial, frag, vert } from '../../src/index'
+import M from '../../src/index'
 import hdr from '../studio_small_04_1k.hdr'
 import voronoi from '../voronoi'
 
@@ -26,13 +26,6 @@ function Env() {
   }, [gl, result, scene])
 
   return null
-}
-
-type Uniforms = {
-  time: any
-  red: any
-  green: any
-  blue: any
 }
 
 function Scene(): JSX.Element {
@@ -57,7 +50,7 @@ function Scene(): JSX.Element {
 
   return (
     <Sphere args={[4, 512, 512]} ref={sphere}>
-      <ComponentMaterial<Uniforms>
+      <M
         ref={material}
         roughness={roughness}
         metalness={metalness}
@@ -70,7 +63,7 @@ function Scene(): JSX.Element {
         }}
         varyings={{ vTransformed: { type: 'vec3' } }}
         color="white">
-        <vert.head>
+        <M.vert.head>
           {/*glsl*/ `
             ${voronoi}
 
@@ -95,8 +88,8 @@ function Scene(): JSX.Element {
               return normalize(cross(distorted1 - distortedPosition, distorted2 - distortedPosition));
             }
           `}
-        </vert.head>
-        <vert.body>
+        </M.vert.head>
+        <M.vert.body>
           {/*glsl*/ `
             float updateTime = time / 10.0;
             
@@ -109,8 +102,8 @@ function Scene(): JSX.Element {
             vNormal = normal + distortedNormal;
             gl_Position = projectionMatrix * modelViewMatrix * vec4(transformed,1.);
           `}
-        </vert.body>
-      </ComponentMaterial>
+        </M.vert.body>
+      </M>
     </Sphere>
   )
 }

--- a/example/pages/voronoi.tsx
+++ b/example/pages/voronoi.tsx
@@ -6,7 +6,7 @@ import { useTweaks } from 'use-tweaks'
 import * as THREE from 'three'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
 
-import M from '../../src/index'
+import {M} from '../../src/index'
 import hdr from '../studio_small_04_1k.hdr'
 import voronoi from '../voronoi'
 

--- a/src/component-material.tsx
+++ b/src/component-material.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useRef } from 'react'
 import { MeshPhysicalMaterial } from 'three'
 import { DEFAULT_STATE, FRAG, VERT, COMMON } from './constants'
 import createMaterial from './create-material'
-import { frag, vert, common } from './proxies'
 import { ChildProps, ComponentMaterialProps, ExtensionShaderObject, ExtensionShadersObject, Uniforms } from './types'
 
 function editShader(shader: string, extensions: ExtensionShaderObject) {
@@ -132,10 +131,3 @@ export const ComponentMaterial = React.forwardRef(function ComponentMaterial(
 
   return <primitive ref={ref} object={material} attach="material" {...props} {..._uniforms} />
 })
-
-// @ts-ignore
-ComponentMaterial.vert = vert
-// @ts-ignore
-ComponentMaterial.frag = frag
-// @ts-ignore
-ComponentMaterial.common = common

--- a/src/component-material.tsx
+++ b/src/component-material.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useRef } from 'react'
 import { MeshPhysicalMaterial } from 'three'
 import { DEFAULT_STATE, FRAG, VERT, COMMON } from './constants'
 import createMaterial from './create-material'
+import { frag, vert, common } from './proxies'
 import { ChildProps, ComponentMaterialProps, ExtensionShaderObject, ExtensionShadersObject, Uniforms } from './types'
 
 function editShader(shader: string, extensions: ExtensionShaderObject) {
@@ -131,3 +132,10 @@ export const ComponentMaterial = React.forwardRef(function ComponentMaterial(
 
   return <primitive ref={ref} object={material} attach="material" {...props} {..._uniforms} />
 })
+
+// @ts-ignore
+ComponentMaterial.vert = vert
+// @ts-ignore
+ComponentMaterial.frag = frag
+// @ts-ignore
+ComponentMaterial.common = common

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,17 @@
 import { ComponentMaterial } from './component-material'
+import { frag, vert, common } from './proxies'
 
-export * from './component-material'
+type MT = typeof ComponentMaterial & {
+  vert: typeof vert
+  frag: typeof frag
+  common: typeof common
+}
 
-export default ComponentMaterial
+// @ts-ignore
+const M: MT = ComponentMaterial
 
-export * from './proxies'
+M.vert = vert
+M.frag = frag
+M.common = common
+
+export default M

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,7 @@
+import { ComponentMaterial } from './component-material'
+
 export * from './component-material'
+
+export default ComponentMaterial
+
 export * from './proxies'


### PR DESCRIPTION
As per @drcmda suggestion
API becomes

```jsx
import Material from 'component-material'

return (
  <Material>
   <Material.common />
   <Material.vert.head />
   <Material.frag.body />
  </Material>
)
```

or for lazy people

```jsx
import M from 'component-material'

return (
  <M>
   <M.common />
   <M.vert.head />
   <M.frag.body />
  </M>
)
```

TODO: frag vert and common types lose suggestions, not sure how to type it correctly