### PR TITLE
Fix "Using the material on more than one mesh breaks it"

### DIFF
--- a/example/pages/main.tsx
+++ b/example/pages/main.tsx
@@ -29,6 +29,7 @@ function Env() {
 
 function Scene() {
   const material = useRef()
+  const material2 = useRef()
 
   const { red, green, blue, metalness, roughness } = useTweaks({
     metalness: { value: 0.5, min: 0, max: 1 },
@@ -58,7 +59,25 @@ function Scene() {
           }
         `}</M.Common>
         <M.Frag.Body>{/*glsl*/ `
-          gl_FragColor = vec4(gl_FragColor.rgb, quadraticInOut((sin(time)+1.0)/2.0));  
+          gl_FragColor = vec4(gl_FragColor.rgb, quadraticInOut((sin(time)+1.0)/2.0));
+        `}</M.Frag.Body>
+      </M>
+      <M
+        ref={material2}
+        metalness={metalness}
+        roughness={roughness}
+        transparent
+        uniforms={{
+          time: { value: 0, type: 'float' },
+        }}>
+        <M.Common>{/*glsl*/ `
+          float quadraticInOut(float t) {
+            float p = 2.0 * t * t;
+            return t < 0.5 ? p : -p + (4.0 * t) - 1.0;
+          }
+        `}</M.Common>
+        <M.Frag.Body>{/*glsl*/ `
+          gl_FragColor = vec4(gl_FragColor.rgb, quadraticInOut((sin(time)+1.0)/2.0));
         `}</M.Frag.Body>
       </M>
     </Sphere>

--- a/example/pages/main.tsx
+++ b/example/pages/main.tsx
@@ -29,7 +29,6 @@ function Env() {
 
 function Scene() {
   const material = useRef()
-  const material2 = useRef()
 
   const { red, green, blue, metalness, roughness } = useTweaks({
     metalness: { value: 0.5, min: 0, max: 1 },
@@ -46,24 +45,6 @@ function Scene() {
     <Sphere args={[4, 512, 512]}>
       <M
         ref={material}
-        metalness={metalness}
-        roughness={roughness}
-        transparent
-        uniforms={{
-          time: { value: 0, type: 'float' },
-        }}>
-        <M.Common>{/*glsl*/ `
-          float quadraticInOut(float t) {
-            float p = 2.0 * t * t;
-            return t < 0.5 ? p : -p + (4.0 * t) - 1.0;
-          }
-        `}</M.Common>
-        <M.Frag.Body>{/*glsl*/ `
-          gl_FragColor = vec4(gl_FragColor.rgb, quadraticInOut((sin(time)+1.0)/2.0));
-        `}</M.Frag.Body>
-      </M>
-      <M
-        ref={material2}
         metalness={metalness}
         roughness={roughness}
         transparent

--- a/src/component-material.tsx
+++ b/src/component-material.tsx
@@ -70,40 +70,43 @@ export const ComponentMaterial = React.forwardRef(function ComponentMaterial(
 
   const shaders = useMemo<ExtensionShadersObject>(
     () =>
-      React.Children.toArray(children).reduce((acc: any, child: any) => {
-        const shader = child?.props?.children
+      React.Children.toArray(children).reduce(
+        (acc: any, child: any) => {
+          const shader = child?.props?.children
 
-        if (typeof shader === 'string') {
-          const replaceChunk = child?.props?.replaceChunk || false
-          const { chunkName, shaderType }: ChildProps = child.type
+          if (typeof shader === 'string') {
+            const replaceChunk = child?.props?.replaceChunk || false
+            const { chunkName, shaderType }: ChildProps = child.type
 
-          if ([VERT, FRAG].includes(shaderType)) {
-            if (chunkName === 'Head') {
-              acc[shaderType].head = acc[shaderType].head.concat(`
+            if ([VERT, FRAG].includes(shaderType)) {
+              if (chunkName === 'Head') {
+                acc[shaderType].head = acc[shaderType].head.concat(`
                   ${shader}
                 `)
-            } else {
-              if (!acc[shaderType][chunkName]) {
-                acc[shaderType][chunkName] = {
-                  value: '',
-                  replaceChunk: false,
+              } else {
+                if (!acc[shaderType][chunkName]) {
+                  acc[shaderType][chunkName] = {
+                    value: '',
+                    replaceChunk: false,
+                  }
                 }
-              }
 
-              acc[shaderType][chunkName].replaceChunk = replaceChunk
-              acc[shaderType][chunkName].value = acc[shaderType][chunkName].value.concat(`
+                acc[shaderType][chunkName].replaceChunk = replaceChunk
+                acc[shaderType][chunkName].value = acc[shaderType][chunkName].value.concat(`
                     ${shader}
                   `)
-            }
-          } else {
-            acc.common = acc.common.concat(`
+              }
+            } else {
+              acc.common = acc.common.concat(`
                 ${shader}
               `)
+            }
           }
-        }
 
-        return acc
-      }, Object.assign({}, DEFAULT_STATE)),
+          return acc
+        },
+        { ...DEFAULT_STATE }
+      ),
     [children]
   )
 

--- a/src/component-material.tsx
+++ b/src/component-material.tsx
@@ -103,7 +103,7 @@ export const ComponentMaterial = React.forwardRef(function ComponentMaterial(
         }
 
         return acc
-      }, DEFAULT_STATE),
+      }, Object.assign({}, DEFAULT_STATE)),
     [children]
   )
 


### PR DESCRIPTION
it appears that `DEFAULT_STATE` was getting modified when it shouldn't have been, the solution is to clone it as necessary