### PR TITLE
Fix shaders accumulator by removing DEFAULT_STATE

### DIFF
--- a/src/component-material.tsx
+++ b/src/component-material.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef } from 'react'
 import { MeshPhysicalMaterial } from 'three'
-import { DEFAULT_STATE, FRAG, VERT } from './constants'
+import { FRAG, VERT } from './constants'
 import createMaterial from './create-material'
 import { ChildProps, ComponentMaterialProps, ExtensionShaderObject, ExtensionShadersObject, Uniforms } from './types'
 
@@ -103,7 +103,15 @@ export const ComponentMaterial = React.forwardRef(function ComponentMaterial(
         }
 
         return acc
-      }, DEFAULT_STATE),
+      }, {
+        vert: {
+          head: '',
+        },
+        frag: {
+          head: '',
+        },
+        common: '',
+      }),
     [children]
   )
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,12 +3,3 @@ export const FRAG = 'frag'
 export const COMMON = 'common'
 export const DEFAULT_VERT_CHUNK = 'project_vertex'
 export const DEFAULT_FRAG_CHUNK = 'dithering_fragment'
-export const DEFAULT_STATE = {
-  vert: {
-    head: '',
-  },
-  frag: {
-    head: '',
-  },
-  common: '',
-}


### PR DESCRIPTION
Since we passed `DEFAULT_STATE` to the reducer as initial value we were updating this object, which will be done each time you use a material. This would then result in substituting or replacing the value multiple times instead of just once. I simply redefined the initial value in the reducer which solves the issue and fixes #9.